### PR TITLE
Debian.yml must be included for Debian *and* Ubuntu distros

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
 
 # Ubuntu specific package installations
 - include: Debian.yml
-  when: ansible_os_family  == "Debian"
+  when: ansible_os_family  == "Debian" or ansible_distribution == "Ubuntu"
 
 # Ubuntu specific package installations
 - include: Ubuntu.yml


### PR DESCRIPTION
@jburwell The Debian.yml file must be included whether the target machine is Ubuntu or Debian.
