### PR TITLE
Add guards to the sysctl and ufw configurations for Ubuntu containers

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,13 @@
 ---
+- name: check proc writeable
+  register: proc_writeable
+  command: test -w /proc/sys/vm/swappiness
+  ignore_errors: yes
+
+- name: update sysctl
+  command: sysctl -e -p /etc/sysctl.d/riak.conf
+  when: proc_writeable|success
+
 - name: update sysctl
   command: sysctl -e -p /etc/sysctl.d/riak.conf
 

--- a/tasks/Ubuntu.yml
+++ b/tasks/Ubuntu.yml
@@ -1,4 +1,5 @@
 ---
 - name: disable ufw
   service: name=ufw state=stopped enabled=no
-
+  register: ufw_result
+  failed_when: "ufw_result|failed and 'not found' not in ufw_result.msg"


### PR DESCRIPTION
Ubuntu containers start with a base minimal base that doesn't contain `ufw`. A guard was added to the task that disables `ufw` so that it fails gracefully when `ufw` is not present.

In addition, `/proc` is not writable. This prevents the plays in this role from tuning kernel level settings via `sysctl`. Guards were put in to ensure `/proc` is writable before attempting to apply new settings with `sysctl`.
